### PR TITLE
Fixed some Bugs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,19 +19,20 @@ Anemone is a testing tool that broadcasts batches of transactions and tests opco
    **maxGas:** max gas to set for each transaction generated, **string**
 
    **chainId:** chainId, **num**
+   
+   **pk:** private key, it starts with **0x...**
 ## Set-up
 * run `yarn install`
 
 ## Start
 
 ### Flags
-**--pk** Private key, takes private key of wallet that will fund the other sender wallet and deploy opcode contracts.
+**--pk** (Optional) private key, takes private key of wallet that will fund the other sender wallet and deploy opcode contracts.
 
 **--rpcport** (Optional), specify url to node open for RPC, defaults to config value
 
-* Must have rpc port exposed on running geth instance.
+* Must have rpc port exposed
 * Must ensure the account associated with the private key provided is sufficiently funded
-* run `yarn start --pk YOUR_PRIVATE_KEY`
+* run `yarn start [OPTIONS]` 
 
 **Please ensure that the account associated with the private key provided is sufficiently funded**
-

--- a/src/anemone.ts
+++ b/src/anemone.ts
@@ -49,7 +49,7 @@ const fundWallets = async (wallets: any[], mainWallet: any): Promise<string[]> =
       chainId: config.chainId
     };
     const txResponse = await mainWallet.sendTransaction(tx);
-    console.log(`sent transaction to fund address ${dest} at provider ${ethers.providers.JsonRpcProvider.url}`);
+    console.log(`sent transaction to fund address ${dest} at provider ${mainWallet.provider.connection["url"]}`);
     txHashes.push(txResponse.hash);
     nonce += 1;
   }
@@ -86,11 +86,11 @@ const batchTxs = async (wallets: any[], provider: JsonRpcProvider) => {
         chainId: config.chainId,
       };
       nonce += 1;
-      sender.sendTransaction(tx);
-      txs.push(tx); 
+      const txHash = await sender.sendTransaction(tx);
+      txs.push(txHash.hash); 
     }
   }
-  console.log(`\nCreated and broadcasted ${txs.length} transactions at provider ${provider.url}`);
+  console.log(`\nCreated and broadcasted ${txs.length} transactions at provider ${provider.connection["url"]} \n`);
   return txs;
 };
 
@@ -101,7 +101,7 @@ const testOpcodes = async (provider: JsonRpcProvider, contractAddresses: any[], 
 
   let nonce = await mainWallet.getTransactionCount();
   let txResponses = [];
-  console.log(`calling testOpcodes at provider at provider ${provider.url}...`);
+  console.log(`calling testOpcodes at provider at provider ${provider.connection["url"]}...`);
 	
   for (let i = 0; i < contractAddresses.length; i++){
     const tx = {
@@ -128,7 +128,7 @@ const testOpcodes = async (provider: JsonRpcProvider, contractAddresses: any[], 
 const testEdgecases = async (provider: JsonRpcProvider, txData: any[], mainWallet) => {
   let nonce = await mainWallet.getTransactionCount();
   let txResponses = [];
-  console.log(`testing edgecases at ${provider.url}...`)
+  console.log(`testing edgecases at ${provider.connection["url"]}...`)
   for (let i = 0; i < txData.length; i++){
     console.log(txData[i]);
     const tx = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,8 @@ const config = {
   //chainId, currently 1337 for kensignton testnet
   chainId: 1337,
 
+  //pk of a funded account
+   pk: '0x0000000000000000000000000000000000000000000000000000000000123456',
 };
 
 export default config;

--- a/src/utilities/isTransactionMined.ts
+++ b/src/utilities/isTransactionMined.ts
@@ -35,7 +35,7 @@ const transactionRecieptExist = async (
 ) => {
   const txResponse = await provider.getTransaction(txHash);
   return new Promise(resolve => {
-    if (txResponse.blockNumber == null) {
+    if (txResponse == null || txResponse.blockNumber == null) {
       setTimeout(async function() {
         const temp = await transactionRecieptExist(txHash, interval, provider);
         resolve(temp);


### PR DESCRIPTION
This PR fixes some bug fixes for the Anemone tests.

File _anemone.ts_:

 - Modified the provider in the console.logs as it previously printed _undefined_
 - Returned the tx hash for the batchTx (to use the _TransactionsMined_  function)

File _index.ts_:

 - Now it is possible to defined the _pk_ in the config file
 - Added the _TransactionsMined_ function for "batch tx" and "testing edgecases". On the latter case, it did not wait for the tx to be mined so getting the transaction information with the tx hash returned _null_

File _isTransactionMined.ts_:

 - Modified the logical check to include _ txResponse == null || txResponse.blockNumber == null_ - If the transaction has not been mined it can return _null_ also


This was tested in Rinkeby and a Moonbeam standalone node, passing the test in both cases.